### PR TITLE
JAMF: remove public IPs + add last seen filter

### DIFF
--- a/jamf/README.md
+++ b/jamf/README.md
@@ -23,6 +23,7 @@
 
 1. (OPTIONAL) - Make any necessary changes to the script to align with your environment.
     - Modify API calls as needed to filter inventory data.
+      - NOTE: `START_DATE` will limit the data fetch to assets seen since the date you input.
     - Modify datapoints uploaded to runZero as needed.
 2. [Create the Credential for the Custom Integration](https://console.runzero.com/credentials).
     - Select the type `Custom Integration Script Secrets`.


### PR DESCRIPTION
Updating JAMF to do a few things:

1. Support a `START_DATE` filter to limit the data fetch to assets seen since X date. This is a workaround until we support datetime. 
2. Limit the IP addresses to private only. JAMF reports unreliable public IP addresses for mobile devices which shouldn't be added to the inventory. These are usually tied to an ISP rather than the actual device since they're all on wifi. 
