### PR TITLE
NEW: send audit events export to webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you need help setting up a custom integration, you can create an [issue](http
 - [Stairwell](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/stairwell/)
 - [Tanium](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/tanium/)
 ## Export from runZero 
-- [General Webhook](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/audit-events-to-webhook/)
+- [Audit Log Webhook](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/audit-events-to-webhook/)
 - [runZero Vunerability Workflow](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/vulnerability-workflow/)
 - [Sumo Logic](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/sumo-logic/)
 ## The boilerplate folder has examples to follow

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If you need help setting up a custom integration, you can create an [issue](http
 - [Stairwell](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/stairwell/)
 - [Tanium](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/tanium/)
 ## Export from runZero 
+- [General Webhook](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/audit-events-to-webhook/)
 - [runZero Vunerability Workflow](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/vulnerability-workflow/)
 - [Sumo Logic](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/sumo-logic/)
 ## The boilerplate folder has examples to follow

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you need help setting up a custom integration, you can create an [issue](http
 - [Stairwell](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/stairwell/)
 - [Tanium](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/tanium/)
 ## Export from runZero 
-- [Audit Log Webhook](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/audit-events-to-webhook/)
+- [Audit Log to Webhook](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/audit-events-to-webhook/)
 - [runZero Vunerability Workflow](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/vulnerability-workflow/)
 - [Sumo Logic](https://github.com/runZeroInc/runzero-custom-integrations/blob/main/sumo-logic/)
 ## The boilerplate folder has examples to follow

--- a/audit-events-to-webhook/README.md
+++ b/audit-events-to-webhook/README.md
@@ -1,0 +1,47 @@
+# runZero Custom Integration: Audit Events to Webhook
+
+This custom integration for runZero exports audit events from your runZero account and sends them to a specified webhook. This allows you to integrate runZero's audit trail with other systems, such as a SIEM or a custom security monitoring tool.
+
+## How it Works
+
+The integration is a Starlark script that performs the following actions:
+
+1.  **Fetches Audit Events:** The script queries the runZero API to retrieve audit events created in the last hour.
+2.  **Formats Events:** The events are formatted as JSON.
+3.  **Sends to Webhook:** The formatted events are sent to a pre-configured webhook URL via an HTTP POST request.
+
+## Configuration
+
+To use this integration, you will need to configure a new custom integration in your runZero account.
+
+1.  **Create a new Custom Integration:** In your runZero console, navigate to `Account > Custom Integrations` and create a new custom integration.
+2.  **Copy the Script:** Copy the contents of the `custom-integration-audit-events.star` file and paste it into the script editor for your new custom integration.
+3.  **Set up Credentials:** The script requires the following credentials to be configured in the custom integration's `access_secret` field as a JSON object:
+
+    *   `webhook_url`: The URL of the webhook to which the audit events will be sent.
+    *   `rz_account_token`: A runZero account token.
+    *   `external_api_key`: An *optional* bearer token for authenticating with the webhook endpoint.
+
+    **Example JSON:**
+
+    ```json
+    {
+      "webhook_url": "https://your-webhook-url.com/endpoint",
+      "external_api_key": "your-bearer-auth-token",
+      "rz_account_token": "your-runzero-export-token"
+    }
+    ```
+
+4.  **Schedule the Integration:** Configure the integration to run on a schedule that meets your needs. The script is designed to fetch events from the last hour, so running it hourly is a good starting point.
+
+## Script Details
+
+The `custom-integration-audit-events.star` script is written in Starlark and uses the built-in `http` and `json` modules to interact with the runZero API and the destination webhook.
+
+### `main` function
+
+The `main` function is the entry point for the script. It retrieves the necessary credentials from the `access_secret`, fetches the latest audit events from the runZero API, and then calls the `send_events_to_webhook` function to send the events to the configured webhook.
+
+### `send_events_to_webhook` function
+
+This function takes a list of events, the webhook URL, and the authentication headers as input. It batches the events into groups of 500 and sends them to the webhook as a series of HTTP POST requests.

--- a/audit-events-to-webhook/config.json
+++ b/audit-events-to-webhook/config.json
@@ -1,0 +1,1 @@
+{ "name": "General Webhook", "type": "outbound" }

--- a/audit-events-to-webhook/config.json
+++ b/audit-events-to-webhook/config.json
@@ -1,1 +1,1 @@
-{ "name": "General Webhook", "type": "outbound" }
+{ "name": "Audit Log Webhook", "type": "outbound" }

--- a/audit-events-to-webhook/config.json
+++ b/audit-events-to-webhook/config.json
@@ -1,1 +1,1 @@
-{ "name": "Audit Log Webhook", "type": "outbound" }
+{ "name": "Audit Log to Webhook", "type": "outbound" }

--- a/audit-events-to-webhook/custom-integration-audit-events.star
+++ b/audit-events-to-webhook/custom-integration-audit-events.star
@@ -1,0 +1,67 @@
+load('http', http_post='post', http_get='get', 'url_encode')
+load('json', json_encode='encode', json_decode='decode')
+load('time', 'parse_time')
+
+def send_events_to_webhook(events, webhook, headers):
+    print("Sending {} events to Webhook".format(len(events)))
+    batchsize = 500
+    if len(events) > 0:
+        for i in range(0, len(events), batchsize):
+            batch = events[i:i+batchsize]
+            tmp = ""
+            for a in batch:
+                tmp = tmp + "{}\n".format(json_encode(a))
+            post_to_webhook = http_post(url=webhook, headers=headers, body=bytes(tmp))
+            print("Response code from Webhook: {}".format(post_to_webhook.status_code))
+    else:
+        print("No events found")
+
+def main(*args, **kwargs):
+    """
+    Export runZero events from the last hour and send to a webhook.
+    Credentials dict passed as:
+    {"webhook_url":"URL","external_api_key":"bearer-auth-token","rz_export_token":"runzero-export-token"}
+    """
+
+    creds = kwargs.get('access_secret')  # runZero passes this as JSON string or dict
+    if type(creds) == 'string':
+        creds = json_decode(creds)
+
+    webhook_url = creds.get('webhook_url')
+    external_api_key = creds.get('external_api_key')
+    rz_token = creds.get('rz_account_token')
+
+    # We'll assume search query supports time filters (e.g. "timestamp > now-1h")
+    search_query = "created:<1h"
+
+    # Request headers for runZero export
+    headers = {
+        "Accept": "application/json"
+    }
+
+    if external_api_key:
+        headers["Authorization"] = "Bearer {}".format(external_api_key)
+
+    # Build runZero API URL
+    base_url = "https://console.runzero.com/api/v1.0"
+    events_url = "https://console.runzero.com/api/v1.0/account/events.json"
+
+    # Fetch events
+    response = http_get(events_url, headers=headers, params={"search": search_query})
+
+    if not response or response.status_code != 200:
+        print("Failed to fetch events from runZero. Status: {}".format(response.body))
+        return []
+
+    events = json_decode(response.body)
+
+    # Send to Webhook
+    headers = {
+        "Content-Type": "application/json"
+    }
+    if external_api_key:
+        headers["Authorization"] = "Bearer {}".format(external_api_key)
+
+    send_events_to_webhook(events, webhook_url, headers)
+
+    return []

--- a/docs/integrations.json
+++ b/docs/integrations.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2025-10-29T13:28:23.435777Z",
+  "lastUpdated": "2025-10-29T13:28:53.818462Z",
   "totalIntegrations": 25,
   "integrationDetails": [
     {
@@ -81,7 +81,7 @@
       "integration": "https://github.com/runZeroInc/runzero-custom-integrations/blob/main/device42/custom-integration-device42.star"
     },
     {
-      "name": "Audit Log Webhook",
+      "name": "Audit Log to Webhook",
       "type": "outbound",
       "readme": "https://github.com/runZeroInc/runzero-custom-integrations/blob/main/audit-events-to-webhook/README.md",
       "integration": "https://github.com/runZeroInc/runzero-custom-integrations/blob/main/audit-events-to-webhook/custom-integration-audit-events.star"

--- a/docs/integrations.json
+++ b/docs/integrations.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2025-10-29T13:27:46.102371Z",
+  "lastUpdated": "2025-10-29T13:28:23.435777Z",
   "totalIntegrations": 25,
   "integrationDetails": [
     {
@@ -81,7 +81,7 @@
       "integration": "https://github.com/runZeroInc/runzero-custom-integrations/blob/main/device42/custom-integration-device42.star"
     },
     {
-      "name": "General Webhook",
+      "name": "Audit Log Webhook",
       "type": "outbound",
       "readme": "https://github.com/runZeroInc/runzero-custom-integrations/blob/main/audit-events-to-webhook/README.md",
       "integration": "https://github.com/runZeroInc/runzero-custom-integrations/blob/main/audit-events-to-webhook/custom-integration-audit-events.star"

--- a/docs/integrations.json
+++ b/docs/integrations.json
@@ -1,6 +1,6 @@
 {
-  "lastUpdated": "2025-10-24T15:50:17.555571Z",
-  "totalIntegrations": 24,
+  "lastUpdated": "2025-10-29T13:27:46.102371Z",
+  "totalIntegrations": 25,
   "integrationDetails": [
     {
       "name": "Lima Charlie",
@@ -79,6 +79,12 @@
       "type": "inbound",
       "readme": "https://github.com/runZeroInc/runzero-custom-integrations/blob/main/device42/README.md",
       "integration": "https://github.com/runZeroInc/runzero-custom-integrations/blob/main/device42/custom-integration-device42.star"
+    },
+    {
+      "name": "General Webhook",
+      "type": "outbound",
+      "readme": "https://github.com/runZeroInc/runzero-custom-integrations/blob/main/audit-events-to-webhook/README.md",
+      "integration": "https://github.com/runZeroInc/runzero-custom-integrations/blob/main/audit-events-to-webhook/custom-integration-audit-events.star"
     },
     {
       "name": "NinjaOne",


### PR DESCRIPTION
## 🆕 New Integration

### Description

This integration pulls the event logs from RZ + pushes them to a webhook. It would generally be used to send the audit logs to a SIEM.

### Checklist

- [x] **New Integration Folder:** A new folder has been created for the integration.  
- [x] **Updated README:** The README has been updated based on the boilerplate to reflect the new integration details.  
- [x] **custom-integration.star File:** The `custom-integration-<name>.star` file has been created/updated as required.  
- [x] **config.json File:** The `config.json` is updated with the `name` (product name) and `type` (inbound or outbound) of integration.
